### PR TITLE
Added length property.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function filterIndices(indices) {
 
 function deleteIndices(client) {
   return function(indices) {
-    if (indices > 0) {
+    if (indices.length > 0) {
       return client.indices.delete({index: indices}).then(function() {
         return indices;
       });


### PR DESCRIPTION
The check for indices length in 'deleteIndices' was missing the actual length property and always returning the list of indices, never actually executing the delete api request.
