### PR TITLE
Add support for AWS Elasticsearch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# Node-lambda environment files
+.env
+deploy.env
+event.json
+context.json

--- a/index.js
+++ b/index.js
@@ -9,11 +9,10 @@ var excludedIndices = (process.env.EXCLUDED_INDICES || ".kibana").split(/[ ,]/).
 var endpoint = process.env.ENDPOINT;
 var indexDate = moment.utc().subtract(+(process.env.MAX_INDEX_AGE || 14), 'days');
 
-exports.handler = function(event, context) {
+exports.handler = function(event, context, callback) {
   var client;
   if (isAWS) {
     var myCredentials = new AWS.EnvironmentCredentials('AWS');
-    console.log(myCredentials);
     client = new elasticsearch.Client({
       hosts: endpoint,
       connectionClass: require('http-aws-es'),
@@ -31,7 +30,7 @@ exports.handler = function(event, context) {
     .then(extractIndices)
     .then(filterIndices)
     .then(deleteIndices(client))
-    .then(report(context.succeed), context.fail);
+    .then(report(callback), callback);
 }
 
 function getIndices(client) {
@@ -64,7 +63,7 @@ function report(cb) {
   return function(indices) {
     var len = indices.length;
     if (len > 0) {
-      cb("Successfully deleted " + len + " indices: " + indices.join(", "));
+      cb(null, "Successfully deleted " + len + " indices: " + indices.join(", "));
     } else {
       cb("There were no indices to delete.");
     }

--- a/index.js
+++ b/index.js
@@ -1,15 +1,32 @@
 var moment = require("moment");
 var elasticsearch = require("elasticsearch");
 
+var isAWS = process.env.IS_AWS || false;
+if (isAWS) var AWS = require('aws-sdk');
+if (isAWS) var region = process.env.AWS_REGION || 'us-east-1';
+
 var excludedIndices = (process.env.EXCLUDED_INDICES || ".kibana").split(/[ ,]/).filter(isPresent);
 var endpoint = process.env.ENDPOINT;
 var indexDate = moment.utc().subtract(+(process.env.MAX_INDEX_AGE || 14), 'days');
 
 exports.handler = function(event, context) {
-  var client = new elasticsearch.Client({
-    host: endpoint
-  });
-
+  var client;
+  if (isAWS) {
+    var myCredentials = new AWS.EnvironmentCredentials('AWS');
+    console.log(myCredentials);
+    client = new elasticsearch.Client({
+      hosts: endpoint,
+      connectionClass: require('http-aws-es'),
+      amazonES: {
+        region: region,
+        credentials: myCredentials
+      }
+    });
+  } else {
+    client = new elasticsearch.Client({
+      host: endpoint
+    });
+  }
   getIndices(client)
     .then(extractIndices)
     .then(filterIndices)

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ function filterIndices(indices) {
 
 function deleteIndices(client) {
   return function(indices) {
-    if (indices > 0) {
+    if (indices.length > 0) {
       return client.indices.delete({index: indices}).then(function() {
         return indices;
       });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "elasticsearch": "^10.1.3",
-    "moment": "^2.12.0"
+    "moment": "^2.12.0",
+    "http-aws-es": "^1.1.3"
   }
 }


### PR DESCRIPTION
Added ability to use this curation script with AWS Elasticsearch instances. The environment variable 'isAWS' is used to maintain the normal functionality of this script for non-AWS ES. If it is set to true then the correct method for authentication when connecting to the AWS ES instance will be used instead.
