### PR TITLE
Add callback parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var endpoint = process.env.ENDPOINT;
 var excludedIndices = (process.env.EXCLUDED_INDICES || '.kibana').split(/[ ,]/);
 var indexDate = moment.utc().subtract(+(process.env.MAX_INDEX_AGE || 14), 'days');
 
-exports.handler = function(event, context) {
+exports.handler = function(event, context, callback) {
   var client = new elasticsearch.Client({
     host: endpoint,
   });
@@ -14,7 +14,7 @@ exports.handler = function(event, context) {
     .then(extractIndices)
     .then(filterIndices)
     .then(deleteIndices(client))
-    .then(report(context.succeed), context.fail);
+    .then(report(callback), callback);
 }
 
 function getIndices(client) {
@@ -43,13 +43,13 @@ function deleteIndices(client) {
   };
 }
 
-function report(cb) {
+function report(callback) {
   return function(indices) {
     var len = indices.length;
     if (len > 0) {
-      cb('Successfully deleted ' + len + ' indices: ' + indices.join(', '));
+      callback(null, 'Successfully deleted ' + len + ' indices: ' + indices.join(', '));
     } else {
-      cb('There were no indices to delete.');
+      callback(null, 'There were no indices to delete.');
     }
   };
 }


### PR DESCRIPTION
The project currently seems to have ben written for the NodeJS v0.10.42 runtime. This change adds the `callback` parameter as documented in [Lambda Function Handler (Node.js)](http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html). Note that this parameter is only supported in the Node.js v4.3 runtime.
