### PR TITLE
Adds support for AWS Elasticsearch

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "elasticsearch": "^10.1.3",
+    "http-aws-es": "^1.1.3",
     "moment": "^2.12.0"
   }
 }


### PR DESCRIPTION
Adds support for communicating with an AWS Elasticsearch cluster (which requires that the HTTP requests are [signed](http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains.html#es-managedomains-signing-service-requests)). This is achieved by utilizing the [`http-aws-es` module](https://www.npmjs.com/package/http-aws-es). The support is enabled by setting the `AWS_REGION` environment variable, which then causes AWS credentials to be pulled from the environment variables using `aws.EnvironmentCredentials('AWS')`.

I have also added a new environment variable, `API_VERSION`, which should be used to set the version of Elasticsearch that is being used. It is not strictly necessary to set this configuration option, but it is recommended to do so in the [documentation](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html#config-api-version). Please enter the commit message for your changes. Lines starting with '#' will be ignored, and an empty message aborts the commit.
